### PR TITLE
Support arbitrary device definitions

### DIFF
--- a/src/Pages/PerformanceTest.js
+++ b/src/Pages/PerformanceTest.js
@@ -1,12 +1,10 @@
 // @flow
-
-import { Button } from '@material-ui/core';
 import * as React from 'react';
 import { useEffect, useState } from "react";
 import PerformanceGraph from '../Components/PerformanceGraph';
-import { generate_model, generate_timestamps } from '../lib/model';
+import { generate_model } from '../lib/model';
 import { simulate_outage } from '../lib/simulator';
-import type { Model, Outage } from '../lib/types'
+import type { Model } from '../lib/types'
 
 export const PerformanceTest = (): React.Node => {
   let [data, setData] = useState({});

--- a/src/lib/data.js
+++ b/src/lib/data.js
@@ -50,7 +50,7 @@ export const DEVICE_WATTAGE: { [Device]: number } = {
   "secondFreezer": 80,
 }
 
-export const HOURLY_FREQ = {
+export const HOURLY_PATTERNS = {
   "meals": [
     0.01, 0.005, 0.005, 0.005, 0.005, 0.01,
     0.03, 0.06, 0.07, 0.06, 0.04, 0.075,

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -10,7 +10,8 @@ export type Device = "dishwasher" |
   "fridge" |
   "freezer" |
   "secondFridge" |
-  "secondFreezer"
+  "secondFreezer" |
+  "custom"
 
 export type QuestionnaireResponse = {
   location: string,
@@ -60,7 +61,7 @@ export type ModelParams = {
 
 export type Model = {
   total_demand: number[], // watts at a given point in time
-  device_demand: { [Device]: number[] },
+  device_demand: { [string]: number[] },
 }
 
 export type Outage = {
@@ -78,6 +79,7 @@ export type DeviceDefinition = {
   freq: number, // cycles per day
   cycle_length: number, // length of cycle
   wattage: number, // nominal watts when turned on
+  pattern: ?string
 }
 
 export type StorageSolution = {


### PR DESCRIPTION
Add support for an additional questionnaire field, `additionalDevices`. We'd ideally like to get to the point where a model is fully generated just from a `devices` entry; i.e. turn the earlier questionnaire answers into a full, combined devices list earlier in the process. This could potentially be done on questionnaire submit, storing the answers in Airtable to persist.

Ideally, `raw questionnaire answers -> list of devices -> model` as three independent representations. The only other metadata needed to generate the model from the list of devices would be the target kWh to scale to; square footage, occupancy, etc. should be represented in the list of devices.

